### PR TITLE
feat: Replace explanation page with alert and add detailed descriptions

### DIFF
--- a/pages/ahliwaris.js
+++ b/pages/ahliwaris.js
@@ -59,17 +59,23 @@ export default function AhliWarisPage() {
   };
 
   const next = () => {
-    // 1. Calculate results to get explanations
-    const tempHarta = 1000; // Use a dummy value for explanation purposes
+    const tempHarta = 1000; // Dummy harta to get statuses
     const hasilPenjelasan = hitungFaraid(tempHarta, waris);
 
-    // 2. Build the explanation string
+    const asabahExplanations = {
+      "'Aṣabah bin-Nafs": "Ashabah bin Nafsi: Mendapat sisa karena kedudukannya sendiri sebagai kerabat laki-laki.",
+      "'Aṣabah bil-Ghair": "Ashabah bil Ghair: Menjadi 'aṣabah karena mewaris bersama ahli waris laki-laki yang setingkat.",
+      "'Aṣabah ma'al-Ghair": "Ashabah ma'al Ghair: Menjadi 'aṣabah karena mewaris bersama ahli waris perempuan lain (anak/cucu perempuan).",
+    };
+
     let alertMessage = "--- Penjelasan Status Ahli Waris ---\n\n";
+
     const blockedHeirs = Object.entries(hasilPenjelasan).filter(([, value]) => value.status.includes("Terhalang"));
     const asabahHeirs = Object.entries(hasilPenjelasan).filter(([, value]) => value.deskripsi.includes("Aṣabah"));
+    const fardhHeirs = Object.entries(hasilPenjelasan).filter(([, value]) => value.deskripsi.includes("Ashabul Furudh"));
 
     if (blockedHeirs.length > 0) {
-      alertMessage += "Ahli Waris Terhalang (Hijab):\n";
+      alertMessage += "AHLI WARIS TERHALANG (HIJAB):\n";
       blockedHeirs.forEach(([key, value]) => {
         alertMessage += `- ${getHeirName(key)}: ${value.deskripsi}\n`;
       });
@@ -77,21 +83,26 @@ export default function AhliWarisPage() {
     }
 
     if (asabahHeirs.length > 0) {
-      alertMessage += "Ahli Waris 'Aṣabah (Penerima Sisa):\n";
-      asabahHeirs.forEach(([key, value]) => {
-        alertMessage += `- ${getHeirName(key)}: ${value.deskripsi}\n`;
+      alertMessage += "STATUS 'AṢABAH (PENERIMA SISA):\n";
+      const asabahTypes = [...new Set(asabahHeirs.map(([, value]) => value.deskripsi))];
+      asabahTypes.forEach(type => {
+        alertMessage += `${asabahExplanations[type] || ''}\n`;
+        const heirsOfType = asabahHeirs.filter(([, value]) => value.deskripsi === type);
+        heirsOfType.forEach(([key]) => {
+          alertMessage += `  - ${getHeirName(key)}\n`;
+        });
       });
       alertMessage += "\n";
     }
 
-    if (blockedHeirs.length === 0 && asabahHeirs.length === 0) {
-      alertMessage += "Semua ahli waris mendapat bagian tetap (Ashabul Furudh)."
+    if (fardhHeirs.length > 0 && asabahHeirs.length === 0 && Object.values(hasilPenjelasan).some(v => v.jumlah > 0)) {
+        alertMessage += "Semua ahli waris yang berhak mendapat bagian tetap (Ashabul Furudh) dan tidak ada sisa (tidak ada 'Aṣabah).\n";
+    } else if (Object.values(hasilPenjelasan).every(v => v.jumlah === 0)) {
+        alertMessage += "Tidak ada ahli waris yang berhak menerima warisan dari daftar yang dipilih.";
     }
 
-    // 3. Show the alert
     alert(alertMessage);
 
-    // 4. Set data and navigate
     setData({ ...data, ahliWaris: waris });
     router.push("/hasil");
   };

--- a/pages/hasil.js
+++ b/pages/hasil.js
@@ -33,8 +33,8 @@ export default function HasilPage() {
     istri: 'Istri',
     ayah: 'Ayah',
     ibu: 'Ibu',
-    kakek: 'Kakek',
-    nenek: 'Nenek',
+    kakek: 'Kakek dari si yang meninggal',
+    nenek: 'Nenek dari si yang meninggal',
     anakL: 'Anak Laki-laki',
     anakP: 'Anak Perempuan',
     cucuL: 'Cucu Laki-laki',
@@ -43,7 +43,20 @@ export default function HasilPage() {
     saudaraP: 'Saudara Perempuan',
   };
 
+  const asabahExplanations = {
+    "'Aṣabah bin-Nafs": "Ashabah bin Nafsi: Mendapat sisa karena kedudukannya sendiri.",
+    "'Aṣabah bil-Ghair": "Ashabah bil Ghair: Menjadi 'aṣabah karena ada ahli waris laki-laki setingkat.",
+    "'Aṣabah ma'al-Ghair": "Ashabah ma'al Ghair: Menjadi 'aṣabah bersama ahli waris perempuan lain.",
+  };
+
   const getHeirName = (key) => heirNames[key] || key;
+
+  const getDeskripsiLengkap = (value) => {
+    if (value.deskripsi && asabahExplanations[value.deskripsi]) {
+      return asabahExplanations[value.deskripsi];
+    }
+    return value.deskripsi || value.status;
+  };
 
   const formatRupiah = (number) => {
     return new Intl.NumberFormat('id-ID', {
@@ -104,7 +117,7 @@ export default function HasilPage() {
                   Object.entries(hasil).map(([key, value]) => (
                     <tr key={key} className={value.status.includes('Terhalang') ? 'bg-red-50 text-gray-500' : 'bg-white'}>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800">{getHeirName(key)}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{value.deskripsi || value.status}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{getDeskripsiLengkap(value)}</td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-800 text-right font-mono">{formatRupiah(value.jumlah)}</td>
                     </tr>
                   ))


### PR DESCRIPTION
This commit implements the user's request to change the application flow and improve the clarity of the results.

- **Replaces Explanation Page with Alert**: The `/penjelasan` page has been removed. The detailed Hijab and 'Aṣabah status information is now presented in an `alert()` dialog on the `ahliwaris` page before navigating to the final results.
- **Simplifies Routing**: The project structure has been simplified by renaming `pages/home.js` back to `pages/index.js` and removing the corresponding redirect from `next.config.js`.
- **Improves 'Aṣabah Descriptions**: The descriptions for 'Aṣabah heirs in both the new alert and the final results table are now more detailed, explaining the type of 'Aṣabah (`bin-Nafs`, `bil-Ghair`, `ma'al-Ghair`) as requested.
- **Updates UI Labels**: The labels for grandparents have been updated for better clarity.