### PR TITLE
feat: Add per-heir share details to results page

### DIFF
--- a/pages/hasil.js
+++ b/pages/hasil.js
@@ -114,13 +114,28 @@ export default function HasilPage() {
               </thead>
               <tbody className="divide-y divide-gray-200">
                 {Object.keys(hasil).length > 0 ? (
-                  Object.entries(hasil).map(([key, value]) => (
-                    <tr key={key} className={value.status.includes('Terhalang') ? 'bg-red-50 text-gray-500' : 'bg-white'}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800">{getHeirName(key)}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{getDeskripsiLengkap(value)}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-800 text-right font-mono">{formatRupiah(value.jumlah)}</td>
-                    </tr>
-                  ))
+                  Object.entries(hasil).map(([key, value]) => {
+                    const count = ahliWaris[key];
+                    const isCountable = ['anakL', 'anakP', 'cucuL', 'cucuP', 'saudaraL', 'saudaraP', 'istri'].includes(key);
+
+                    return (
+                      <tr key={key} className={value.status.includes('Terhalang') ? 'bg-red-50 text-gray-500' : 'bg-white'}>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800">
+                          {getHeirName(key)}
+                          {isCountable && count > 1 ? <span className="font-normal text-gray-500"> (x{count})</span> : ''}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{getDeskripsiLengkap(value)}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-800 text-right font-mono">
+                          <div>{formatRupiah(value.jumlah)}</div>
+                          {isCountable && count > 1 && value.jumlah > 0 && (
+                            <div className="text-xs text-gray-500">
+                              (@ {formatRupiah(value.jumlah / count)} / org)
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })
                 ) : (
                   <tr>
                     <td colSpan="3" className="px-6 py-4 text-center text-gray-500">Tidak ada ahli waris yang berhak menerima.</td>


### PR DESCRIPTION
This commit enhances the UI of the results page (`/hasil`) to provide a clearer breakdown of the inheritance distribution, as requested by the user.

- Displays the count of heirs for groups (e.g., 'Anak Laki-laki (x4)').
- Calculates and shows the per-person share for these groups (e.g., '(@ Rp 100.000 / org)').
- This makes the final calculation much easier to understand when multiple heirs of the same type exist.